### PR TITLE
Separate registration code verification feature

### DIFF
--- a/Insightly/Areas/Identity/Pages/Account/Register.cshtml
+++ b/Insightly/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model RegisterModel
 @{
     ViewData["Title"] = "Register";
@@ -56,6 +56,26 @@
                             <p class="mb-0">Already have an account? <a asp-page="./Login" asp-route-returnUrl="@Model.ReturnUrl" class="text-decoration-none">Login now</a></p>
                         </div>
                     </form>
+
+                    <hr class="my-4" />
+
+                    <div>
+                        <h5 class="mb-3">Already registered?</h5>
+                        <p class="text-muted small mb-3">Enter your email to verify your account using the code you received.</p>
+                        <form method="post" asp-page-handler="Verify" class="row g-2 align-items-center">
+                            <div class="col-12 col-md-8">
+                                <input asp-for="VerificationEmail" class="form-control" type="email" placeholder="name@example.com" />
+                            </div>
+                            <div class="col-12 col-md-4 d-grid">
+                                <button type="submit" class="btn btn-outline-primary">
+                                    <i class="bi bi-shield-check me-1"></i>Verify Code
+                                </button>
+                            </div>
+                            <div class="col-12">
+                                <span asp-validation-for="VerificationEmail" class="text-danger small"></span>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
 

--- a/Insightly/Areas/Identity/Pages/Account/VerifyCode.cshtml
+++ b/Insightly/Areas/Identity/Pages/Account/VerifyCode.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model VerifyCodeModel
 @{
     ViewData["Title"] = "Verify Email";
@@ -36,12 +36,7 @@
                             <i class="bi bi-check-circle me-1"></i>Verify Email
                         </button>
 
-                        <div class="text-center">
-                            <p class="mb-2 text-muted small">Didn't receive the code?</p>
-                            <button type="submit" asp-page-handler="ResendCode" class="btn btn-link p-0 text-decoration-none">
-                                <i class="bi bi-arrow-clockwise me-1"></i>Resend Code
-                            </button>
-                        </div>
+                        
                     </form>
 
                     <div class="mt-4 text-center">

--- a/Insightly/Areas/Identity/Pages/Account/VerifyCode.cshtml.cs
+++ b/Insightly/Areas/Identity/Pages/Account/VerifyCode.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Insightly.Models;
@@ -16,20 +16,17 @@ namespace Insightly.Areas.Identity.Pages.Account
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly IVerificationCodeService _verificationCodeService;
-        private readonly IEmailSender _emailSender;
         private readonly ILogger<VerifyCodeModel> _logger;
 
         public VerifyCodeModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             IVerificationCodeService verificationCodeService,
-            IEmailSender emailSender,
             ILogger<VerifyCodeModel> logger)
         {
             _userManager = userManager;
             _signInManager = signInManager;
             _verificationCodeService = verificationCodeService;
-            _emailSender = emailSender;
             _logger = logger;
         }
 
@@ -125,58 +122,6 @@ namespace Insightly.Areas.Identity.Pages.Account
             return Page();
         }
 
-        public async Task<IActionResult> OnPostResendCodeAsync()
-        {
-            var userId = TempData["UserId"]?.ToString();
-            var userEmail = TempData["UserEmail"]?.ToString();
-
-            if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(userEmail))
-            {
-                return RedirectToPage("./Register");
-            }
-
-            var user = await _userManager.FindByIdAsync(userId);
-
-            if (user != null)
-            {
-                // Invalidate old code
-                await _verificationCodeService.InvalidateCodeAsync(userId);
-
-                // Generate new code
-                var newCode = await _verificationCodeService.GenerateCodeAsync(userId);
-
-                // Send email with new code
-                var emailSubject = "New Verification Code";
-                var emailBody = $@"
-                    <html>
-                    <body style='font-family: Arial, sans-serif; background-color: #f4f4f4; padding: 20px;'>
-                        <div style='max-width: 600px; margin: 0 auto; background-color: white; padding: 30px; border-radius: 10px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);'>
-                            <h2 style='color: #333; text-align: center;'>New Verification Code</h2>
-                            <p style='color: #666; font-size: 16px;'>Hello {user.Name},</p>
-                            <p style='color: #666; font-size: 16px;'>Here is your new verification code:</p>
-                            <div style='background-color: #f8f9fb; padding: 20px; border-radius: 8px; text-align: center; margin: 20px 0;'>
-                                <h1 style='color: #007bff; letter-spacing: 8px; font-size: 36px; margin: 0;'>{newCode}</h1>
-                            </div>
-                            <p style='color: #999; font-size: 14px; text-align: center;'>This code will expire in 15 minutes</p>
-                            <hr style='border: none; border-top: 1px solid #eee; margin: 30px 0;'>
-                            <p style='color: #999; font-size: 12px; text-align: center;'>If you didn't request this verification code, please ignore this email.</p>
-                        </div>
-                    </body>
-                    </html>";
-
-                await _emailSender.SendEmailAsync(userEmail, emailSubject, emailBody);
-
-                TempData["InfoMessage"] = "A new verification code has been sent to your email.";
-            }
-
-            UserEmail = userEmail;
-
-            // Keep the data
-            TempData.Keep("UserId");
-            TempData.Keep("UserEmail");
-            TempData.Keep("ReturnUrl");
-
-            return Page();
-        }
+        
     }
 }


### PR DESCRIPTION
Remove "Resend Code" functionality and add a separate "Verify Code" option on the registration page for existing users.

The "Resend Code" button and its associated logic were removed from the `VerifyCode` page. A new "Verify Code" form was added to the `Register` page, allowing users who have already registered (but not yet verified) to input their email and navigate directly to the `VerifyCode` page to enter their existing code. This provides an alternative verification entry point without affecting the primary registration-to-verification flow or the reset password functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1562105-da64-481e-8fab-743fb48c1505">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1562105-da64-481e-8fab-743fb48c1505">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

